### PR TITLE
Only default to tigre if GPU is present

### DIFF
--- a/cuqipy_cil/config.py
+++ b/cuqipy_cil/config.py
@@ -17,17 +17,19 @@ try:
 except ImportError:
     pass
 
-try:
-    import tigre
-    _detected_backend = "tigre"
-except ImportError:
-    pass
+# Try defaulting to tigre (only if GPU is available)
+if _detected_device == "gpu":
+    try:
+        import tigre
+        _detected_backend = "tigre"
+    except ImportError:
+        pass
 
 if _detected_backend is None:
     raise ImportError("No projector backend found. Please install either astra or tigre.")
 
 PROJECTION_BACKEND = _detected_backend
-""" Projection backend to use. Currently supported: "tigre", "astra". Defaults to tigre if present, otherwise astra. """
+""" Projection backend to use. Currently supported: "tigre", "astra". Defaults to tigre if possible, otherwise astra. """
 
 PROJECTION_BACKEND_DEVICE = _detected_device
 """ Device to use for projection backend. Currently supported: "cpu", "gpu". Defaults to GPU if present, otherwise cpu. Only relevant for astra backend. """


### PR DESCRIPTION
Hi @jakobsj, Minor issue I found if user somehow installed tigre but had no GPU, the library would still default to tigre.

Closes #9 